### PR TITLE
feat: Add mouse button information to events and update related hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ https://github.com/zenobi-us/ink-mouse/assets/61225/658ad469-6438-4bff-8695-e2fe
 - Mouse hover tracking
 - Mouse click tracking
 - Mouse drag tracking
+- Mouse button detection
 - Element position tracking
 
 [Todo](#todo)
@@ -29,6 +30,7 @@ import {
   useMousePosition,
   useOnMouseClick,
   useMouse,
+  useMouseAction,
 } from '@zenobius/ink-mouse';
 import { useMap } from '@react-hookz/web';
 
@@ -43,6 +45,7 @@ function App() {
 function MyComponent() {
   const mouse = useMouse();
   const mousePosition = useMousePosition();
+  const mouseAction = useMouseAction();
   const map = useMap<'button1', number>() // Example of a simple state map
 
   /**
@@ -62,6 +65,7 @@ function MyComponent() {
       <Box flexDirection="column" gap={1}>
         <Text>{JSON.stringify(mousePosition)}</Text>
         <Text>Button 1 clicked: {map.get('button1') || 0} times</Text>
+        <Text>Mouse Action Button: {mouseAction.button}</Text>
       </Box>
     </Box>
   );
@@ -78,7 +82,7 @@ function Button({ label, onClick }: { label: string; onClick?: () => void }) {
     if (event && typeof onClick === 'function') {
       onClick();
     }
-  });
+  }, 'left');
   useOnMouseHover(ref, setHovering);
 
   const border = useMemo((): ComponentProps<typeof Box>['borderStyle'] => {
@@ -151,5 +155,3 @@ All project tasks are managed via Mise in `.mise/tasks/`, you can list them via 
   - Apparently old CMD.exe only supports [rudimentary ansii escape codes for colours](https://ss64.com/nt/syntax-ansi.html).
   - New Windows Terminal does support ansi escape codes, so we'd have to explore what works and what doesn't.
   - We might have to fall back to GPM or some other library. Seems a bit complex. want to avoid it if possible.
-- [ ] Add support for right and middle click.
-  - I think these are supported by the terminal, but I'm not sure how to detect them. Is it lowercase M and R?

--- a/src/ink-mouse/Fullscreen.tsx
+++ b/src/ink-mouse/Fullscreen.tsx
@@ -3,7 +3,7 @@ import { Box } from "ink";
 import type { PropsWithChildren } from "react";
 import { useTerminalSize } from "./useTerminalSize";
 
-function Fullscreen(props: PropsWithChildren<{}>) {
+function Fullscreen(props: PropsWithChildren<Record<string, never>>) {
     const terminal = useTerminalSize();
     return (
         <Box flexGrow={1} width={terminal.width} height={terminal.height}>

--- a/src/ink-mouse/MouseContext.ts
+++ b/src/ink-mouse/MouseContext.ts
@@ -10,6 +10,7 @@ type MousePosition = {
 type MouseClickAction = 'press' | 'release' | null;
 type MouseScrollAction = 'scrollup' | 'scrolldown' | null;
 type MouseDragAction = 'dragging' | null;
+type MouseButton = 'left' | 'middle' | 'right' | 'back' | 'forward' | null;
 
 type MouseAction = MouseClickAction | MouseScrollAction;
 
@@ -22,6 +23,7 @@ const MouseContext = createContext<MouseContextShape>({
   drag: null,
   position: { x: 0, y: 0 },
   scroll: null,
+  button: null,
   disable: () => {},
   enable: () => {},
   toggle: () => {},
@@ -34,5 +36,6 @@ export type {
   MouseClickAction,
   MouseScrollAction,
   MouseDragAction,
+  MouseButton,
   MouseAction,
 };

--- a/src/ink-mouse/ansiParser.ts
+++ b/src/ink-mouse/ansiParser.ts
@@ -1,4 +1,6 @@
-import { ANSI_RESPONSE_PATTERNS } from './constants';
+import type { MouseClickButton, MouseDragButton } from './constants';
+import { ANSI_RESPONSE_PATTERNS, MOUSE_BUTTONS } from './constants';
+import type { MouseButton } from './MouseContext';
 
 const parseXYCoordinates = (input: string, pattern: RegExp) => {
   if (!pattern.test(input)) {
@@ -34,10 +36,19 @@ const parseXYScroll = (
   return { x, y, direction };
 };
 
+const parseMouseButton = (
+  button: MouseClickButton | MouseDragButton,
+): NonNullable<MouseButton> => MOUSE_BUTTONS[button] || 'left';
+
 const parseXYClick = (
   input: string,
   pattern: RegExp,
-): { x: number; y: number; action: 'press' | 'release' } | null => {
+): {
+  x: number;
+  y: number;
+  action: 'press' | 'release';
+  button: 'left' | 'middle' | 'right' | 'back' | 'forward';
+} | null => {
   if (!pattern.test(input)) {
     return null;
   }
@@ -45,10 +56,13 @@ const parseXYClick = (
   if (!match) {
     return null;
   }
-  const x = Number(match[1]);
-  const y = Number(match[2]);
-  const action = match[3] === 'M' ? 'press' : 'release';
-  return { x, y, action };
+  const button: MouseButton = parseMouseButton(
+    Number(match[1]) as MouseClickButton | MouseDragButton,
+  );
+  const x = Number(match[2]);
+  const y = Number(match[3]);
+  const action = match[4] === 'M' ? 'press' : 'release';
+  return { x, y, action, button };
 };
 
 const AnsiSgrParser = {

--- a/src/ink-mouse/constants.ts
+++ b/src/ink-mouse/constants.ts
@@ -1,3 +1,5 @@
+import type { MouseButton } from './MouseContext';
+
 const ANSI_CODES = {
   // SET_X10_MOUSE
   mouseX10: { on: '\x1b[?9h', off: '\x1b[?9l' },
@@ -6,9 +8,9 @@ const ANSI_CODES = {
   // SET_VT200_MOUSE
   mouseButton: { on: '\x1b[?1000h', off: '\x1b[?1000l' },
 
-  // Terminal will send position of the column hilighted
+  // Terminal will send position of the column highlighted
   // SET_VT200_HIGHLIGHT_MOUSE
-  mouseHilight: { on: '\x1b[?1001h', off: '\x1b[?1001l' },
+  mouseHighlight: { on: '\x1b[?1001h', off: '\x1b[?1001l' },
 
   // Terminal will send event on button pressed and mouse motion as long as a button is down, with mouse position
   // SET_BTN_EVENT_MOUSE
@@ -40,9 +42,34 @@ const ANSI_CODES = {
 
 const ANSI_RESPONSE_PATTERNS = {
   scroll: /\[<(64|65);(\d+);(\d+)M$/,
-  drag: /\[<32;(\d+);(\d+)([Mm])$/,
+  drag: /\[<(32|33|34|160|161);(\d+);(\d+)([Mm])$/,
   move: /\[<35;(\d+);(\d+)M$/,
-  click: /\[<0;(\d+);(\d+)([Mm])$/,
+  click: /\[<(0|1|2|128|129);(\d+);(\d+)([Mm])$/,
 };
 
-export { ANSI_CODES, ANSI_RESPONSE_PATTERNS };
+type MouseClickButton = 0 | 1 | 2 | 128 | 129;
+type MouseDragButton = 32 | 33 | 34 | 160 | 161;
+
+const MOUSE_CLICK_BUTTONS: Record<MouseClickButton, MouseButton> = {
+  0: 'left',
+  1: 'middle',
+  2: 'right',
+  128: 'back',
+  129: 'forward',
+};
+
+const MOUSE_DRAG_BUTTONS: Record<MouseDragButton, MouseButton> = {
+  32: 'left',
+  33: 'middle',
+  34: 'right',
+  160: 'back',
+  161: 'forward',
+};
+
+const MOUSE_BUTTONS = {
+  ...MOUSE_CLICK_BUTTONS,
+  ...MOUSE_DRAG_BUTTONS,
+};
+
+export { ANSI_CODES, ANSI_RESPONSE_PATTERNS, MOUSE_BUTTONS };
+export type { MouseClickButton, MouseDragButton };

--- a/src/ink-mouse/createXtermMouseEvents.ts
+++ b/src/ink-mouse/createXtermMouseEvents.ts
@@ -1,4 +1,5 @@
 import type {
+  MouseButton,
   MouseClickAction,
   MouseDragAction,
   MousePosition,
@@ -9,9 +10,9 @@ import { TypedEventEmitter } from './createEventEmitter';
 const createXtermMouseEvents = () => {
   return new TypedEventEmitter<{
     position: (position: MousePosition) => void;
-    click: (position: MousePosition, action: MouseClickAction) => void;
+    click: (position: MousePosition, action: MouseClickAction, button: MouseButton) => void;
     scroll: (position: MousePosition, direction: MouseScrollAction) => void;
-    drag: (position: MousePosition, action: MouseDragAction) => void;
+    drag: (position: MousePosition, action: MouseDragAction, button: MouseButton) => void;
     listen: (yesno: boolean) => void;
   }>();
 };

--- a/src/ink-mouse/useMouseAction.ts
+++ b/src/ink-mouse/useMouseAction.ts
@@ -5,23 +5,25 @@ import type {
   MouseClickAction,
   MouseDragAction,
   MouseScrollAction,
+  MouseButton,
 } from './MouseContext';
 
 function useMouseAction() {
   const mouse = useMouse();
-  const [action, setAction] = useState<
-    MouseClickAction | MouseScrollAction | MouseDragAction | null
-  >();
+  const [action, setAction] = useState<{
+    action: MouseClickAction | MouseScrollAction | MouseDragAction | null;
+    button: MouseButton | null;
+  }>({ action: null, button: null });
 
   useEffect(() => {
-    mouse.events.on('click', (position, action) => {
-      setAction(action);
+    mouse.events.on('click', (position, action, button) => {
+      setAction({ action, button });
     });
     mouse.events.on('scroll', (position, action) => {
-      setAction(action);
+      setAction({ action, button: null });
     });
-    mouse.events.on('drag', (position, action) => {
-      setAction(action);
+    mouse.events.on('drag', (position, action, button) => {
+      setAction({ action, button });
     });
   }, [mouse.position.x, mouse.position.y]);
 

--- a/src/ink-mouse/useOnMouseClick.ts
+++ b/src/ink-mouse/useOnMouseClick.ts
@@ -2,13 +2,18 @@ import { useCallback, useEffect, useMemo, type RefObject } from 'react';
 import { type DOMElement } from 'ink';
 
 import { useMouse } from './useMouse';
-import type { MouseClickAction, MousePosition } from './MouseContext';
+import type {
+  MouseClickAction,
+  MousePosition,
+  MouseButton,
+} from './MouseContext';
 import { isIntersecting } from './isIntersecting';
 import { useElementDimensions, useElementPosition } from './useElementPosition';
 
 function useOnMouseClick(
   ref: RefObject<DOMElement | null>,
   onChange: (event: boolean) => void,
+  button: MouseButton = 'left',
 ) {
   const mouse = useMouse();
   const elementPosition = useElementPosition(ref);
@@ -24,9 +29,11 @@ function useOnMouseClick(
   ])
 
   const handler = useCallback(
-    (position: MousePosition, action: MouseClickAction) => {
+    (position: MousePosition, action: MouseClickAction, eventButton: MouseButton) => {
       onChange(
-        isIntersecting({ element, mouse: position }) && action === 'press',
+        isIntersecting({ element, mouse: position }) &&
+        action === 'press' &&
+        eventButton === button
       );
     },
     [ref.current],

--- a/src/ink-mouse/useOnMouseState.ts
+++ b/src/ink-mouse/useOnMouseState.ts
@@ -1,14 +1,15 @@
 import { useState, type RefObject } from 'react';
 import { type DOMElement } from 'ink';
 
+import type { MouseButton } from './MouseContext';
 import { useOnMouseClick } from './useOnMouseClick';
 import { useOnMouseHover } from './useOnMouseHover';
 
-function useOnMouseState(ref: RefObject<DOMElement>) {
+function useOnMouseState(ref: RefObject<DOMElement>, button: MouseButton = 'left') {
   const [hovering, setHovering] = useState(false);
   const [clicking, setClicking] = useState(false);
 
-  useOnMouseClick(ref, setClicking);
+  useOnMouseClick(ref, setClicking, button);
   useOnMouseHover(ref, setHovering);
 
   return { hovering, clicking };

--- a/src/ink-mouse/useXtermMouse.ts
+++ b/src/ink-mouse/useXtermMouse.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 
 import type {
+  MouseButton,
   MouseClickAction,
   MouseDragAction,
   MousePosition,
@@ -12,76 +13,77 @@ import {
 } from './createXtermMouseEvents';
 import { xtermMouse } from './xtermMouse';
 
-
 type MouseStatus = 'enabled' | 'disabled';
 
 function useXtermMouse() {
-  const [status,setStatus] = useState<MouseStatus>('enabled')
+  const [status, setStatus] = useState<MouseStatus>('enabled');
   const events = useRef<XtermMouseEvents>(createXtermMouseEvents());
   const position = useRef<MousePosition>({
     x: 0,
     y: 0,
   });
-  const click = useRef<MouseClickAction >(null);
+  const click = useRef<MouseClickAction>(null);
   const scroll = useRef<MouseScrollAction>(null);
   const drag = useRef<MouseDragAction>(null);
+  const button = useRef<MouseButton>(null);
 
   const mouse = useRef(
     xtermMouse({
       onPosition: (newPosition) => {
         if (status === 'disabled') {
-          return
+          return;
         }
         position.current = newPosition;
         events.current.emit('position', newPosition);
       },
-      onClick: (newClick) => {
+      onClick: (newClick, newButton) => {
         if (status === 'disabled') {
-          return
+          return;
         }
         click.current = newClick;
-        events.current.emit('click', position.current, newClick);
+        button.current = newButton;
+        events.current.emit('click', position.current, newClick, newButton);
       },
       onScroll: (newScroll) => {
         if (status === 'disabled') {
-          return
+          return;
         }
         scroll.current = newScroll;
         events.current.emit('scroll', position.current, newScroll);
       },
-      onDrag: (newDrag) => {
+      onDrag: (newDrag, newButton) => {
         if (status === 'disabled') {
-          return
+          return;
         }
         drag.current = newDrag;
-        events.current.emit('drag', position.current, newDrag);
+        button.current = newButton;
+        events.current.emit('drag', position.current, newDrag, newButton);
       },
     }),
   );
 
   const disable = () => {
     mouse.current.disable();
-    setStatus('disabled')
-  }
-  const enable =  () => {
+    setStatus('disabled');
+  };
+  const enable = () => {
     mouse.current.enable();
-    setStatus('enabled')
-  }
+    setStatus('enabled');
+  };
   const toggle = () => {
     if (status === 'enabled') {
       disable();
     } else {
       enable();
     }
-  }
+  };
 
   useEffect(() => {
-    enable()
+    enable();
     return () => {
-      disable()
+      disable();
     };
   }, []);
-
 
   return {
     enable,
@@ -92,6 +94,7 @@ function useXtermMouse() {
     click: click.current,
     drag: drag.current,
     scroll: scroll.current,
+    button: button.current,
     events: events.current,
   };
 }

--- a/src/ink-mouse/xtermMouse.ts
+++ b/src/ink-mouse/xtermMouse.ts
@@ -1,4 +1,5 @@
 import type {
+  MouseButton,
   MouseClickAction,
   MouseDragAction,
   MousePosition,
@@ -14,8 +15,8 @@ export function xtermMouse({
   onDrag,
 }: {
   onPosition: (position: MousePosition) => void;
-  onClick: (action: MouseClickAction) => void;
-  onDrag: (direction: MouseDragAction) => void;
+  onClick: (action: MouseClickAction, button: MouseButton) => void;
+  onDrag: (direction: MouseDragAction, button: MouseButton) => void;
   onScroll: (direction: MouseScrollAction) => void;
 }) {
   const handleEvent = (input: string) => {
@@ -25,7 +26,7 @@ export function xtermMouse({
         return;
       }
       onPosition(position);
-      onDrag(position.action === 'press' ? 'dragging' : null);
+      onDrag(position.action === 'press' ? 'dragging' : null, position.button);
       return;
     }
 
@@ -44,9 +45,9 @@ export function xtermMouse({
         return;
       }
       onPosition(position);
-      onClick(position.action);
+      onClick(position.action, position.button);
       setTimeout(() => {
-        onClick(null);
+        onClick(null, null);
       }, 100);
       return;
     }
@@ -78,12 +79,12 @@ export function xtermMouse({
   const enable = () => {
     process.stdout.write(
       ANSI_CODES.mouseButton.on +
-      ANSI_CODES.mouseMotion.on +
-      ANSI_CODES.mouseMotionOthers.on +
-      ANSI_CODES.mouseSGR.on,
+        ANSI_CODES.mouseMotion.on +
+        ANSI_CODES.mouseMotionOthers.on +
+        ANSI_CODES.mouseSGR.on,
     );
     process.stdin.on('data', handleEvent);
-  }
+  };
 
   return { disable, enable };
 }


### PR DESCRIPTION
This commit introduces the ability to track which mouse button is pressed
during click and drag events.

- `MouseContext.ts`: Updated to include `MouseButton` type and `button` in initial context.
- `ansiParser.ts`: Enhanced to parse mouse button information from ANSI sequences.
- `constants.ts`: Added mappings for mouse button codes to their string representations.
- `createXtermMouseEvents.ts`: Modified `click` and `drag` events to emit button information.
- `useXtermMouse.ts`: Updated to return the current `button` state.
- `useOnMouseClick.ts`: Modified to accept an optional `button` argument for filtering clicks.
- `useOnMouseState.ts`: Updated to pass the `button` argument to `useOnMouseClick`.
- `useMouseAction.ts`: Changed to return both the `action` and the `button` for mouse events.
- `Fullscreen.tsx`: Fixed a TypeScript error by changing `{}` to `Record<string, never>`.
- `useOnMouseState.ts`: Fixed import order/spacing to comply with ESLint rules.